### PR TITLE
fix(packages): remove sssd cluster packages causing ostree update failures

### DIFF
--- a/build_files/base/04-packages.sh
+++ b/build_files/base/04-packages.sh
@@ -52,7 +52,6 @@ FEDORA_PACKAGES=(
     libgda-sqlite
     libimobiledevice
     libratbag-ratbagd
-    libsss_autofs
     libxcrypt-compat
     lm_sensors
     make
@@ -76,8 +75,6 @@ FEDORA_PACKAGES=(
     samba-winbind-clients
     samba-winbind-modules
     setools-console
-    sssd-ad
-    sssd-krb5
     sssd-nfs-idmap
     switcheroo-control
     tmux


### PR DESCRIPTION
## Summary

Removes `libsss_autofs`, `sssd-ad`, and `sssd-krb5` from `build_files/base/04-packages.sh`.

These packages pull in a dependency chain that causes silent ostree update failures due to incorrect SELinux labeling of `sssd-passkey` artifacts in `/usr/libexec/sssd/passkey_child`.

Mirrors Aurora PR 1811 ("fix: workaround selinux issues which breaks image updates", merged 2026-02-25) and Aurora PR 1911 ("chore: remove remaining sssd packages", merged 2026-03-15).

## Changes

- `build_files/base/04-packages.sh` — remove `libsss_autofs`, `sssd-ad`, `sssd-krb5`

`sssd-nfs-idmap` is retained — Aurora did not remove it.

## Testing

- [ ] CI build passes

Closes #4