### PR TITLE
chore(ci): add Sigstore build attestations

### DIFF
--- a/.github/workflows/build-image-beta.yml
+++ b/.github/workflows/build-image-beta.yml
@@ -14,6 +14,13 @@ on:
   workflow_call:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+  attestations: write
+  artifact-metadata: write
+
 jobs:
   build-image-beta:
     name: Build Beta Images

--- a/.github/workflows/build-image-latest-main.yml
+++ b/.github/workflows/build-image-latest-main.yml
@@ -13,6 +13,13 @@ on:
   workflow_call:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+  attestations: write
+  artifact-metadata: write
+
 jobs:
   build-image-latest:
     name: Build Latest Images

--- a/.github/workflows/build-image-stable.yml
+++ b/.github/workflows/build-image-stable.yml
@@ -14,6 +14,13 @@ on:
   workflow_call:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+  attestations: write
+  artifact-metadata: write
+
 jobs:
   build-image-stable:
     name: Build Stable Images

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -26,10 +26,18 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}-${{ inputs.brand_name}}-${{ inputs.stream_name }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   build_container:
     name: image
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+      artifact-metadata: write
     continue-on-error: false
     strategy:
       fail-fast: false
@@ -300,6 +308,14 @@ jobs:
           SBOM_DIGEST: ${{ steps.upload-sbom.outputs.sbom_digest }}
         run: |
           cosign sign -y --key env://COSIGN_PRIVATE_KEY ${LOWERCASE}/${IMAGE_NAME}@${SBOM_DIGEST}
+
+      - name: Attestation
+        if: github.event_name != 'pull_request'
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 #v4.1.0
+        with:
+          subject-name: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.push.outputs.outputs && fromJSON(steps.push.outputs.outputs).digest }}
+          push-to-registry: true
 
   check:
     name: Check all ${{ matrix.stream_name }} builds successful


### PR DESCRIPTION
## Summary

Mirrors Aurora PRs 1872 and 1947 — adds Sigstore/cosign build attestations to all build workflows.

## Changes

- Add `attestations: write` + `artifact-metadata: write` to top-level `permissions:` in `build-image-beta.yml`, `build-image-latest-main.yml`, `build-image-stable.yml`
- Add `permissions: {}` at top level of `reusable-build.yml` (locks down inherited permissions)
- Add job-level `permissions:` block to `build_container` in `reusable-build.yml`
- Add `Attestation` step (pinned `actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26`) after SBOM sign step in `reusable-build.yml`

## Aurora references

- Aurora PR 1872 — "chore(ci): add build attestations" — merged 2026-03-22
- Aurora PR 1947 — "fix(ci): add attestations: write permission" — merged 2026-03-22

## Testing

This PR exists to trigger CI on castrojo/bluefin to verify the workflow changes are valid before upstreaming to ublue-os/bluefin.

Closes #12

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>