### PR TITLE
fix(packages): add autofs and restrict ROCm to non-nvidia dx

### DIFF
--- a/build_files/base/04-packages.sh
+++ b/build_files/base/04-packages.sh
@@ -20,6 +20,7 @@ FEDORA_PACKAGES=(
     adcli
     adw-gtk3-theme
     adwaita-fonts-all
+    autofs
     bash-color-prompt
     bcache-tools
     bootc

--- a/build_files/dx/00-dx.sh
+++ b/build_files/dx/00-dx.sh
@@ -49,9 +49,6 @@ FEDORA_PACKAGES=(
     qemu-system-x86-core
     qemu-user-binfmt
     qemu-user-static
-    rocm-hip
-    rocm-opencl
-    rocm-smi
     sysprof
     incus
     incus-agent
@@ -68,6 +65,14 @@ FEDORA_PACKAGES=(
 
 echo "Installing ${#FEDORA_PACKAGES[@]} DX packages from Fedora repos..."
 dnf5 -y install "${FEDORA_PACKAGES[@]}"
+
+# rocm doesn't work well on nvidia
+if [[ ! "${IMAGE_NAME}" =~ nvidia ]]; then
+  dnf install -y \
+    rocm-hip \
+    rocm-opencl \
+    rocm-smi
+fi
 
 dnf config-manager addrepo --from-repofile=https://download.docker.com/linux/fedora/docker-ce.repo
 sed -i "s/enabled=.*/enabled=0/g" /etc/yum.repos.d/docker-ce.repo

--- a/build_files/dx/01-tests-dx.sh
+++ b/build_files/dx/01-tests-dx.sh
@@ -13,7 +13,6 @@ IMPORTANT_PACKAGES_DX=(
     flatpak-builder
     libvirt
     qemu
-    rocm-runtime
 )
 
 for package in "${IMPORTANT_PACKAGES_DX[@]}"; do


### PR DESCRIPTION
## Summary

- Add `autofs` to base packages for on-demand network filesystem mounting (NFS, SMB)
- Restrict ROCm (`rocm-hip`, `rocm-opencl`, `rocm-smi`) to non-nvidia dx images — ROCm is AMD-only and does not function on nvidia hardware
- Remove `rocm-runtime` from dx test suite since it is no longer unconditionally installed

## Aurora references

- Aurora PR 1897 — "feat(packages): add autofs" — merged 2026-03-14
- Aurora PR 1732 — "fix(packages): remove ROCm from nvidia-dx" — merged 2026-02-08

## Files changed

- `build_files/base/04-packages.sh` — add `autofs`
- `build_files/dx/00-dx.sh` — remove ROCm from `FEDORA_PACKAGES`, add `! nvidia` conditional block
- `build_files/dx/01-tests-dx.sh` — remove `rocm-runtime` from test list

Closes #11, closes #15